### PR TITLE
fix small typo, .val() -> .eval()

### DIFF
--- a/schedulefree/adamw_schedulefree.py
+++ b/schedulefree/adamw_schedulefree.py
@@ -14,7 +14,7 @@ class AdamWScheduleFree(torch.optim.Optimizer):
     To add warmup, rather than using a learning rate schedule you can just
     set the warmup_steps parameter.
     
-    This optimizer requires that .train() and .val() be called before the
+    This optimizer requires that .train() and .eval() be called before the
     beginning of training and evaluation respectively.
     
     Arguments:


### PR DESCRIPTION
Small typo in docstring.

Reference code: https://github.com/facebookresearch/schedule_free/blob/main/examples/mnist/main.py

```python
def test(model, optimizer, device, test_loader):
    model.eval()
    optimizer.eval()
    test_loss = 0
    correct = 0
    with torch.no_grad():
        for data, target in test_loader:
            data, target = data.to(device), target.to(device)
            output = model(data)
            test_loss += F.nll_loss(output, target, reduction='sum').item()  # sum up batch loss
            pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
            correct += pred.eq(target.view_as(pred)).sum().item()

    test_loss /= len(test_loader.dataset)

    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.2f}%)\n'.format(
        test_loss, correct, len(test_loader.dataset),
        100. * correct / len(test_loader.dataset)))

```