### PR TITLE
Update tensor device on train and eval function

### DIFF
--- a/schedulefree/adamw_schedulefree.py
+++ b/schedulefree/adamw_schedulefree.py
@@ -82,7 +82,7 @@ class AdamWScheduleFree(torch.optim.Optimizer):
                     state = self.state[p]
                     if 'z' in state:
                         # Set p.data to x
-                        p.data.lerp_(end=state['z'], weight=1-1/beta1)
+                        p.data.lerp_(end=state['z'].to(p.data.device), weight=1-1/beta1)
                 group['train_mode'] = False
 
     def train(self):


### PR DESCRIPTION
Added `.to(p.data.device)` to ensure `p.data` can be `lerp_` with `state['z']`.

Avoids error relating to different devices like `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

Reason for PR: During evaluation-only mode, I noticed that `state['z']` was loaded on `cpu` when `p.data` is in `cuda`.

Let me know if this fix is relevant and I'll do it for the other optimizers' eval function.