### PR TITLE
Update tensor device on train and eval function

### DIFF
--- a/schedulefree/adamw_schedulefree.py
+++ b/schedulefree/adamw_schedulefree.py
@@ -82,7 +82,7 @@ class AdamWScheduleFree(torch.optim.Optimizer):
                     state = self.state[p]
                     if 'z' in state:
                         # Set p.data to x
-                        p.data.lerp_(end=state['z'], weight=1-1/beta1)
+                        p.data.lerp_(end=state['z'].to(p.data.device), weight=1-1/beta1)
                 group['train_mode'] = False
 
     def train(self):

--- a/schedulefree/adamw_schedulefree.py
+++ b/schedulefree/adamw_schedulefree.py
@@ -94,7 +94,7 @@ class AdamWScheduleFree(torch.optim.Optimizer):
                     state = self.state[p]
                     if 'z' in state:
                         # Set p.data to y
-                        p.data.lerp_(end=state['z'], weight=1-beta1)
+                        p.data.lerp_(end=state['z'].to(p.data.device), weight=1-beta1)
                 group['train_mode'] = True
 
     def step(self, closure=None):

--- a/schedulefree/sgd_schedulefree.py
+++ b/schedulefree/sgd_schedulefree.py
@@ -82,7 +82,7 @@ class SGDScheduleFree(torch.optim.Optimizer):
                     state = self.state[p]
                     if 'z' in state:
                         # Set p.data to x
-                        p.data.lerp_(end=state['z'], weight=1-1/momentum)
+                        p.data.lerp_(end=state['z'].to(p.data.device), weight=1-1/momentum)
                 group['train_mode'] = False
 
     def train(self):
@@ -94,7 +94,7 @@ class SGDScheduleFree(torch.optim.Optimizer):
                     state = self.state[p]
                     if 'z' in state:
                         # Set p.data to y
-                        p.data.lerp_(end=state['z'], weight=1-momentum)
+                        p.data.lerp_(end=state['z'].to(p.data.device), weight=1-momentum)
                 group['train_mode'] = True
 
     def step(self, closure=None):


### PR DESCRIPTION
> Reopen from #41 due to issue with GitHub processing.

Added `.to(p.data.device)` to ensure `p.data` can be `lerp_` with `state['z']`.

Avoids error relating to different devices like `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

This ensures the optimizer is allocated to the matching torch.device to avoid device mismatch errors, especially when the optimizer is resumed for training or during evaluation-only mode.

Normally on first training, the device mismatch error wouldn't error due to the use of torch.clone in the step function at `self.state[p]['z'] = torch.clone(p.data)`. However, if the step function isn't called like during continuation of training or evaluation-only mode, a device mismatch error could occur.
